### PR TITLE
Fix Account History period report date issue

### DIFF
--- a/apps/database/lib/database/schemas/account.ex
+++ b/apps/database/lib/database/schemas/account.ex
@@ -169,7 +169,7 @@ defmodule DataBase.Schemas.Account do
   defp range_today(nil), do: nil
 
   defp range_today(%Date{} = date) do
-    Date.range(date, to_date(DateTime.utc_now))
+    Date.range(date, Date.utc_today)
   end
 
   @spec opening_date(t) :: Date.t() | nil

--- a/apps/database/test/database/schemas/account_history_test.exs
+++ b/apps/database/test/database/schemas/account_history_test.exs
@@ -18,7 +18,7 @@ defmodule DataBase.Schemas.AccountHistoryTest do
 
       Subject.register(movement)
 
-      {:ok, report} = Subject.report(movement.account, Faker.today)
+      {:ok, report} = Subject.report(movement.account, Date.utc_today)
 
       assert :eq == D.cmp(movement.amount, report.final_balance)
       assert :eq == D.cmp(movement.amount, report.inbounds)
@@ -32,7 +32,7 @@ defmodule DataBase.Schemas.AccountHistoryTest do
       account = Factories.Accounts.opened
       balance = Account.balance(account)
 
-      {:ok, report} = Subject.report(account, Faker.today)
+      {:ok, report} = Subject.report(account, Date.utc_today)
 
       assert :eq == D.cmp(balance, report.final_balance)
       assert :eq == D.cmp(balance, report.inbounds)

--- a/apps/database/test/database/schemas/account_movement_test.exs
+++ b/apps/database/test/database/schemas/account_movement_test.exs
@@ -101,7 +101,7 @@ defmodule DataBase.Schemas.AccountMovementTest do
       build = Subject.build(account.id, amount, 1)
       balance = Account.balance(account)
 
-      move_on = %{move_on: DateTime.to_date(DateTime.utc_now)}
+      move_on = %{move_on: Date.utc_today}
       movement = struct(build, move_on)
 
       inbounds_on = D.add(balance, amount)
@@ -117,7 +117,7 @@ defmodule DataBase.Schemas.AccountMovementTest do
       account = Factories.Accounts.opened
       build = Subject.build(account.id, amount, -1)
 
-      move_on = %{move_on: DateTime.to_date(DateTime.utc_now)}
+      move_on = %{move_on: Date.utc_today}
       movement = struct(build, move_on)
 
       result = Subject.outbounds_on(movement)

--- a/apps/database/test/database/schemas/account_test.exs
+++ b/apps/database/test/database/schemas/account_test.exs
@@ -126,7 +126,7 @@ defmodule DataBase.Schemas.AccountTest do
       inbounds = D.add(balance, amount)
       {:ok, _credit} = Subject.credit(account, amount)
 
-      result = Subject.inbounds_on(account.id, Faker.today)
+      result = Subject.inbounds_on(account.id, Date.utc_today)
 
       assert :eq == D.cmp(inbounds, result)
     end
@@ -142,7 +142,7 @@ defmodule DataBase.Schemas.AccountTest do
       {:ok, _debit} = Subject.debit(account, amount)
       {:ok, _debit} = Subject.debit(account, amount)
 
-      result = Subject.outbounds_on(account.id, Faker.today)
+      result = Subject.outbounds_on(account.id, Date.utc_today)
 
       assert :eq = D.cmp(outbounds, result)
     end
@@ -151,7 +151,7 @@ defmodule DataBase.Schemas.AccountTest do
   describe "early_balance/2" do
     test "returns the initial_balance of a given date" do
       account = SubjectFactory.opened
-      result = Subject.early_balance(account.id, Faker.today)
+      result = Subject.early_balance(account.id, Date.utc_today)
 
       assert :eq == D.cmp(0, result.initial_balance)
     end

--- a/apps/database/test/support/faker.exs
+++ b/apps/database/test/support/faker.exs
@@ -28,14 +28,6 @@ defmodule DataBase.Test.Support.Faker do
   end
 
   @doc """
-  The current `t:Date.t/0`.
-  """
-  @spec today() :: Date.t()
-  def today do
-    DateTime.to_date(DateTime.utc_now)
-  end
-
-  @doc """
   A radius/center based `t:Date.Range.t/0` generator.
 
   Given a positive integer (defaults to `5`) as radius and a
@@ -43,7 +35,7 @@ defmodule DataBase.Test.Support.Faker do
   respective `t:Date.Range.t/0`.
   """
   @spec date_range(integer, Date.t) :: Date.Range.t()
-  def date_range(radius \\ 5, center \\ today()) do
+  def date_range(radius \\ 5, center \\ Date.utc_today) do
     center
     |> Date.add((radius * -1))
     |> Date.range(Date.add(center, radius))

--- a/apps/teller/lib/teller/graphql/resolvers/account_history/date.ex
+++ b/apps/teller/lib/teller/graphql/resolvers/account_history/date.ex
@@ -34,7 +34,7 @@ defmodule Teller.GraphQL.Resolvers.AccountHistory.Date do
   @spec report(any, any) :: History.report_result_t()
 
   defp report(account, nil) do
-    History.report(account, today())
+    History.report(account, Date.utc_today)
   end
 
   defp report(account, %Date{} = date) do
@@ -43,10 +43,5 @@ defmodule Teller.GraphQL.Resolvers.AccountHistory.Date do
 
   defp report(_account, _period) do
     Error.invalid_input
-  end
-
-  @spec today() :: Date.t()
-  defp today do
-    DateTime.to_date(DateTime.utc_now())
   end
 end

--- a/apps/teller/lib/teller/graphql/resolvers/account_history/period.ex
+++ b/apps/teller/lib/teller/graphql/resolvers/account_history/period.ex
@@ -34,7 +34,7 @@ defmodule Teller.GraphQL.Resolvers.AccountHistory.Period do
   @spec report(any, any, any) :: History.report_result_t()
 
   defp report(account, %Date{} = from, %Date{} = to) do
-    with true     <- (from < to),
+    with :lt      <- Date.compare(from, to),
          period   <- Date.range(from, to) do
       History.report(account, period)
     else

--- a/apps/teller/test/teller/graphql/resolvers/account_history/date_test.exs
+++ b/apps/teller/test/teller/graphql/resolvers/account_history/date_test.exs
@@ -14,7 +14,7 @@ defmodule Teller.GraphQL.Resolvers.AccountHistory.DateTest do
   describe "account history date resolver" do
     test "requires authorization" do
       account = Factories.Accounts.opened
-      today = Faker.today
+      today = Date.utc_today
 
       query = """
       {
@@ -33,7 +33,7 @@ defmodule Teller.GraphQL.Resolvers.AccountHistory.DateTest do
 
     test "reports over a single date" do
       account = Factories.Accounts.opened
-      today = Faker.today
+      today = Date.utc_today
 
       query = """
       {

--- a/apps/teller/test/teller/graphql/resolvers/account_history/month_test.exs
+++ b/apps/teller/test/teller/graphql/resolvers/account_history/month_test.exs
@@ -14,7 +14,7 @@ defmodule Teller.GraphQL.Resolvers.AccountHistory.MonthTest do
   describe "account history month resolver" do
     test "requires authorization" do
       account = Factories.Accounts.opened
-      {year, month, _day} = Date.to_erl(Faker.today)
+      {year, month, _day} = Date.to_erl(Date.utc_today)
 
       query = """
       {
@@ -33,7 +33,7 @@ defmodule Teller.GraphQL.Resolvers.AccountHistory.MonthTest do
 
     test "reports over a month/year pair" do
       account = Factories.Accounts.opened
-      {year, month, _day} = Date.to_erl(Faker.today)
+      {year, month, _day} = Date.to_erl(Date.utc_today)
 
       query = """
       {

--- a/apps/teller/test/teller/graphql/resolvers/account_history/period_test.exs
+++ b/apps/teller/test/teller/graphql/resolvers/account_history/period_test.exs
@@ -14,7 +14,7 @@ defmodule Teller.GraphQL.Resolvers.AccountHistory.PeriodTest do
   describe "account history period resolver" do
     test "requires authorization" do
       account = Factories.Accounts.opened
-      from = Faker.today
+      from = Date.utc_today
       to = Date.add(from, 10)
 
       query = """
@@ -34,7 +34,7 @@ defmodule Teller.GraphQL.Resolvers.AccountHistory.PeriodTest do
 
     test "reports over a from/to date pair" do
       account = Factories.Accounts.opened
-      from = Faker.today
+      from = Date.utc_today
       to = Date.add(from, 10)
 
       query = """

--- a/apps/teller/test/teller/graphql/resolvers/account_history/year_test.exs
+++ b/apps/teller/test/teller/graphql/resolvers/account_history/year_test.exs
@@ -14,7 +14,7 @@ defmodule Teller.GraphQL.Resolvers.AccountHistory.YearTest do
   describe "account history year resolver" do
     test "requires authorization" do
       account = Factories.Accounts.opened
-      {year, _month, _day} = Date.to_erl(Faker.today)
+      {year, _month, _day} = Date.to_erl(Date.utc_today)
 
       query = """
       {
@@ -33,7 +33,7 @@ defmodule Teller.GraphQL.Resolvers.AccountHistory.YearTest do
 
     test "reports over a year" do
       account = Factories.Accounts.opened
-      {year, _month, _day} = Date.to_erl(Faker.today)
+      {year, _month, _day} = Date.to_erl(Date.utc_today)
 
       query = """
       {


### PR DESCRIPTION
Turns out that comparisons between `Date.t` using the `>` and similar operators isn't reliable. So `Date.compare/2` is being used instead.

Also `Date.utc_today/0` is being used as a major way to reach for the current date.